### PR TITLE
Adds a Replace command

### DIFF
--- a/stellar/command.py
+++ b/stellar/command.py
@@ -147,6 +147,22 @@ def rename(old_name, new_name):
 
 
 @stellar.command()
+@click.argument('name')
+def replace(name):
+    """Replaces a snapshot"""
+    app = Stellar()
+
+    snapshot = app.get_snapshot(name)
+    if not snapshot:
+        print "Couldn't find snapshot %s" % name
+        sys.exit(1)
+
+    app.remove_snapshot(snapshot)
+    app.create_snapshot(name)
+    print "Replaced snapshot %s" % name
+
+
+@stellar.command()
 def init():
     """Initializes Stellar configuration."""
     while True:


### PR DESCRIPTION
A convenience command that just wraps the remove and snapshot commands so that an existing named snapshot can be replaced in one step.

Use case is when using named snapshots to switch between development branches (e.g. naming the snapshots branchA, branchB, etc) but update the corresponding branch snapshot before you switch. In other words use Stellar to keep each branch's snapshot in its last used state, ready for when it's returned to.

Equivalent to `stellar remove [name]` followed by `stellar snapshot [name]`. Yes, that could just as easily be a command line alias, but it's a trivial addition.

(Also fixed a bug when calling `stellar restore` without a name and no existing snapshots.) 
