### PR TITLE
Preserve Ownership of database and tables

### DIFF
--- a/stellar/models.py
+++ b/stellar/models.py
@@ -42,6 +42,7 @@ class Table(Base):
     snapshot_id = sa.Column(
         sa.Integer, sa.ForeignKey(Snapshot.id), nullable=False
     )
+    owner = sa.Column(sa.String(255), nullable=False)
     snapshot = sa.orm.relationship(Snapshot, backref='tables')
 
     def get_table_name(self, postfix, old=False):


### PR DESCRIPTION
This PR is just to start the discussion about this feature and should not be considered for merging.

In my use case, in a single project I have two databases and each one has to be accessed by different users, so I need a way to keep the original ownership of each database after restoring a snapshot.

In order to achieve this I create one new connection to each database and alter the owner of it and all of its objects with REASSIGN OWNED. It works for me currently but it has some bugs and has the postgres username hardcoded.

BUG: REASSIGN OWNED seems to change not only the objects in the current database, but all of the objects, including databases that are shared. This means that all the stellar master/slave databases will also change ownership. As long as the user that you specify in your connection url is a super user it is not a problem for this to work but it is far from desirable.