### PR TITLE
bugfix: Fix TypeError exception when showing message that a required library is not installed

### DIFF
--- a/stellar/command.py
+++ b/stellar/command.py
@@ -277,8 +277,7 @@ def main():
         for library, name in libraries.items():
             if str(e) == 'No module named %s' % library:
                 click.echo("Python library %s is required for %s support." %
-                    library,
-                    name
+                           (library, name)
                 )
                 click.echo("You can install it with pip:")
                 click.echo("pip install %s" % library)


### PR DESCRIPTION
This fixed a minor string formatting issue that was causing a TypeError to be raised whenever the a user tried to connect to a database for which the required library was not installed.

This was preventing the help message from being displayed.

**This is what was happening** 

```
Please enter the url for your database.

For example:
PostgreSQL: postgresql://localhost:5432/
MySQL: mysql+pymysql://root@localhost/: postgresql://localhost:5432/

Traceback (most recent call last):
  File ",,,/bin/stellar", line 9, in <module>
    load_entry_point('stellar==0.4.1', 'console_scripts', 'stellar')()
  File ".../local/lib/python2.7/site-packages/stellar/command.py", line 280, in main
    library,
TypeError: not enough arguments for format string
```

**And this is how it looks now that it's fixed, which I assume is what it was initially intended to look like:**

```
Please enter the url for your database.

For example:
PostgreSQL: postgresql://localhost:5432/
MySQL: mysql+pymysql://root@localhost/: postgresql://localhost:5432/

Python library psycopg2 is required for PostreSQL support.
You can install it with pip:
pip install psycopg2
```
