### PR TITLE
Fixed TypeError

### DIFF
--- a/stellar/command.py
+++ b/stellar/command.py
@@ -276,10 +276,10 @@ def main():
         }
         for library, name in libraries.items():
             if str(e) == 'No module named %s' % library:
-                click.echo("Python library %s is required for %s support." %
+                click.echo("Python library %s is required for %s support." % (
                     library,
                     name
-                )
+                ))
                 click.echo("You can install it with pip:")
                 click.echo("pip install %s" % library)
                 sys.exit(1)


### PR DESCRIPTION
I didn't have `pymysql` installed but the error reporting code crashed with the following error:

```
Traceback (most recent call last):
  File "venv/bin/stellar", line 9, in <module>
    load_entry_point('stellar==0.4.1', 'console_scripts', 'stellar')()
  File "/path/venv/lib/python2.7/site-packages/stellar/command.py", line 280, in main
    library,
TypeError: not enough arguments for format string
```
