### PR TITLE
Bump humanize version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 PyYAML==3.11
 SQLAlchemy==0.9.6
-humanize==0.5
+humanize==0.5.1
 pytest==2.5.2
 schema==0.3.1
 psutil==2.1.1

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     install_requires = [
         'PyYAML==3.11',
         'SQLAlchemy==0.9.6',
-        'humanize==0.5',
+        'humanize==0.5.1',
         'pytest==2.5.2',
         'schema==0.3.1',
         'click==3.1',


### PR DESCRIPTION
Humanize 0.5 fails to install on Windows due to a bug in the setup.py, but 0.5.1 works fine.